### PR TITLE
Handle precomputed registration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ This is the directory with your input dataset formatted according to the BIDS st
 
 #### `output_dir`
 
-This is the directory where the output files should be stored. If you are running group level analysis, this folder should be prepopulated with the results of the participant level analysis.
+This is the directory where the output files should be stored. If you are running group level analysis, this folder should be prepopulated with the results of the participant level analysis.  
+If a file named `<prefix>_from-pet_to-t1w_reg.lta` exists inside `sub-*/[ses-*/]` folders of this directory, the workflow reuses it and skips the registration step.
 
 #### `analysis_level`
 


### PR DESCRIPTION
## Summary
- skip MRICoreg when a registration is already in the output directory
- add helper function to reuse or compute registration
- describe this feature in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683ed2bb1cb083309258436ea59ca522